### PR TITLE
Add flag to not include your current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ pepper - v0.1.0
   -d    run in debug mode
   -dry-run
         do not change branch settings just print the changes that would occur
+  -nouser
+        do not include your user
   -orgs value
         organizations to include
   -token string
         GitHub API token
+  -url string
+        GitHub Enterprise URL
   -v    print version and exit (shorthand)
   -version
         print version and exit


### PR DESCRIPTION
This allows pepper to only update repos for an org, without doing it for the current user (default functionality still there).